### PR TITLE
chore: release v0.2.0 (rename to capiscio-sdk)

### DIFF
--- a/capiscio_sdk/__init__.py
+++ b/capiscio_sdk/__init__.py
@@ -8,7 +8,7 @@ Example:
     >>> agent = secure(MyAgentExecutor())
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # Core exports
 from .executor import CapiscioSecurityExecutor, secure, secure_agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capiscio-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Runtime security middleware for A2A agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps the package version to `0.2.0` to signify the major refactor and renaming of the package.

Includes all changes from the rename refactor.