### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ pip install capiscio-sdk==0.1.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-11-23
+
+### Fixed
+- **Release Automation**: Bumped version to trigger fresh GitHub Release and PyPI publication with correct artifacts.
+
 ## [0.3.0] - 2025-11-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capiscio-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = "Runtime security middleware for A2A agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps version to 0.3.1 to trigger a fresh release process, ensuring GitHub Release artifacts are correctly attached.