### PR TITLE
fix: run only unit tests in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,9 +29,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       
-      - name: Run tests
+      - name: Run unit tests
         run: |
-          pytest tests/ -v --tb=short
+          # Only run unit tests in publish workflow
+          # Integration tests require capiscio-server and capiscio-core binary
+          pytest tests/unit/ -v --tb=short
   
   build-and-publish:
     needs: test  # Only publish if tests pass


### PR DESCRIPTION
## Problem

The publish workflow was running all tests including integration tests, which require:
- capiscio-server running on localhost:8080
- capiscio-core binary installed

These dependencies are not available in the publish workflow environment, causing release failures.

## Solution

Changed the publish workflow to only run unit tests (`pytest tests/unit/`).

The full integration test suite continues to run in the dedicated `integration-tests.yml` workflow which spins up the proper Docker infrastructure.