### PR TITLE
chore: bump version to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [2.3.1] - 2025-01-14
+
+### Fixed
+- Fixed `__version__` in package `__init__.py` (was 0.3.1, now 2.3.1)
+- Aligned all version references across package metadata
+
 ## [0.1.0] - 2025-01-10
 
 ### Added

--- a/capiscio_sdk/__init__.py
+++ b/capiscio_sdk/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> result = validate_agent_card(card_dict)  # Uses Go core
 """
 
-__version__ = "0.3.1"
+__version__ = "2.3.1"
 
 # Core exports
 from .executor import CapiscioSecurityExecutor, secure, secure_agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capiscio-sdk"
-version = "2.3.0"
+version = "2.3.1"
 description = "Runtime security middleware for A2A agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Bumps version to 2.3.1 to fix version misalignment from the 2.3.0 release.

## Changes
- Updated `pyproject.toml` version to 2.3.1
- Updated `capiscio_sdk/__init__.py` version to 2.3.1 (was incorrectly at 0.3.1)
- Added [2.3.1] changelog entry

## Context
The 2.3.0 release had version mismatches across packages. This release aligns all CapiscIO packages to 2.3.1.