### PR TITLE
chore: Prepare v2.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-02-08
+
+### Added
+- **CapiscIO.connect()**: "Let's Encrypt" style one-liner agent setup
+  - Single API call handles key generation, DID creation, registration, and badge request
+  - Cryptographic operations performed by capiscio-core Go library via gRPC
+  - Context manager support for automatic resource cleanup
+- **CapiscIO.from_env()**: Initialize from `CAPISCIO_API_KEY` environment variable
+- **AgentIdentity**: Dataclass representing a fully-configured agent
+  - `emit()`: Send events to the registry
+  - `status()`: Get agent status including badge validity
+  - `close()`: Clean up resources (also works as context manager)
+- **EventEmitter**: Agent event emission with batching
+  - Thread-safe batch operations
+  - Automatic flush on batch size threshold
+  - Convenience methods: `task_started()`, `task_completed()`, `task_failed()`, `tool_call()`, `tool_result()`
+
+### Fixed
+- **httpx exception handling**: Network errors now raise `RuntimeError` with sanitized messages
+- **Error message sanitization**: Removed `resp.text` from error messages to prevent API key exposure
+
 ## [2.4.0] - 2026-01-18
 
 ### Fixed

--- a/capiscio_sdk/__init__.py
+++ b/capiscio_sdk/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> result = validate_agent_card(card_dict)  # Uses Go core
 """
 
-__version__ = "2.3.1"
+__version__ = "2.4.1"
 
 # Core exports
 from .executor import CapiscioSecurityExecutor, secure, secure_agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capiscio-sdk"
-version = "2.4.0"
+version = "2.4.1"
 description = "Runtime security middleware for A2A agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
Prepare release v2.4.1 with the Let's Encrypt-style connect flow feature.

## Changes
- Update version to 2.4.1 in pyproject.toml and __init__.py
- Add CHANGELOG entry for v2.4.1

## Changelog
```markdown
## [2.4.1] - 2026-02-08
### Added
- **CapiscIO.connect()**: Let's Encrypt-style one-liner agent setup
- **EventEmitter**: Agent event emission with batching  
- **AgentIdentity**: Dataclass with emit(), status(), close() methods
- Thread-safe batch operations with threading.Lock
- httpx network error handling with sanitized messages
```

## Release Checklist
- [ ] CI passes
- [ ] Merge to main
- [ ] Create tag v2.4.1
- [ ] Create GitHub Release to trigger npm publish