### PR TITLE
fix: use PID-specific socket path to avoid orphan process contention

### DIFF
--- a/capiscio_sdk/_rpc/process.py
+++ b/capiscio_sdk/_rpc/process.py
@@ -21,7 +21,35 @@ logger = logging.getLogger(__name__)
 # Default socket path — use PID-specific path to avoid contention
 # with orphaned capiscio-core processes from previous runs.
 DEFAULT_SOCKET_DIR = Path.home() / ".capiscio"
-DEFAULT_SOCKET_PATH = DEFAULT_SOCKET_DIR / f"rpc-{os.getpid()}.sock"
+
+
+def _default_socket_path() -> Path:
+    """Compute PID-specific socket path lazily at runtime.
+
+    This must NOT be computed at import time because forked child processes
+    would inherit the parent's PID-based path and contend on the same socket.
+    """
+    return DEFAULT_SOCKET_DIR / f"rpc-{os.getpid()}.sock"
+
+
+def _cleanup_stale_sockets() -> None:
+    """Remove rpc-*.sock files whose PID is no longer running."""
+    try:
+        for sock in DEFAULT_SOCKET_DIR.glob("rpc-*.sock"):
+            try:
+                pid_str = sock.stem.split("-", 1)[1]
+                pid = int(pid_str)
+                os.kill(pid, 0)  # Check if PID exists
+            except (ValueError, IndexError):
+                sock.unlink(missing_ok=True)
+            except ProcessLookupError:
+                # PID doesn't exist — stale socket
+                logger.debug("Removing stale socket %s", sock)
+                sock.unlink(missing_ok=True)
+            except PermissionError:
+                pass  # PID exists but owned by another user
+    except OSError:
+        pass
 
 # Binary download configuration
 CORE_VERSION = "2.5.0"
@@ -74,7 +102,7 @@ class ProcessManager:
             return self._tcp_address
         if self._socket_path:
             return f"unix://{self._socket_path}"
-        return f"unix://{DEFAULT_SOCKET_PATH}"
+        return f"unix://{_default_socket_path()}"
     
     @property
     def is_running(self) -> bool:
@@ -352,10 +380,13 @@ class ProcessManager:
     ) -> str:
         """Start the gRPC server with a Unix socket listener."""
         # Set up socket path
-        self._socket_path = socket_path or DEFAULT_SOCKET_PATH
+        self._socket_path = socket_path or _default_socket_path()
         
         # Ensure socket directory exists
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        # Clean up stale sockets from previous runs
+        _cleanup_stale_sockets()
         
         # Remove stale socket
         if self._socket_path.exists():

--- a/capiscio_sdk/_rpc/process.py
+++ b/capiscio_sdk/_rpc/process.py
@@ -18,9 +18,10 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# Default socket path
+# Default socket path — use PID-specific path to avoid contention
+# with orphaned capiscio-core processes from previous runs.
 DEFAULT_SOCKET_DIR = Path.home() / ".capiscio"
-DEFAULT_SOCKET_PATH = DEFAULT_SOCKET_DIR / "rpc.sock"
+DEFAULT_SOCKET_PATH = DEFAULT_SOCKET_DIR / f"rpc-{os.getpid()}.sock"
 
 # Binary download configuration
 CORE_VERSION = "2.5.0"

--- a/tests/unit/test_process.py
+++ b/tests/unit/test_process.py
@@ -302,8 +302,8 @@ class TestProcessManager:
         pm = ProcessManager()
         pm._tcp_address = None
         pm._socket_path = None
-        from capiscio_sdk._rpc.process import DEFAULT_SOCKET_PATH
-        assert pm.address == f"unix://{DEFAULT_SOCKET_PATH}"
+        from capiscio_sdk._rpc.process import _default_socket_path
+        assert pm.address == f"unix://{_default_socket_path()}"
 
 
 class TestChecksumVerification:


### PR DESCRIPTION
## Problem

When a Python process using the SDK crashes or is killed without cleanup, the `capiscio-darwin-arm64` RPC sidecar process can become orphaned while still holding the shared `~/.capiscio/rpc.sock` Unix socket. Subsequent SDK invocations then connect to the orphaned process's socket, causing hangs or timeouts.

## Fix

Changed `DEFAULT_SOCKET_PATH` from `rpc.sock` to `rpc-{pid}.sock` so each Python process gets its own socket. Orphaned sidecar processes no longer block new SDK connections.

## Changes

- `capiscio_sdk/_rpc/process.py` — PID-specific socket path + cleanup of stale PID sockets on startup

## Testing

Verified in a2a-demos (demo-one, demo-two) where multiple sequential runs previously hung due to orphaned processes.