### PR TITLE
fix(ci): GA-026 gate publish on integration tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'  # Trigger on version tags like v0.1.0, v1.0.0, etc.
+  workflow_dispatch:
+    inputs:
+      skip_integration:
+        description: 'Skip integration tests (emergency only)'
+        required: false
+        default: 'false'
 
 jobs:
   # Run full test suite before publishing
@@ -30,13 +36,39 @@ jobs:
           pip install -e ".[dev]"
       
       - name: Run unit tests
-        run: |
-          # Only run unit tests in publish workflow
-          # Integration tests require capiscio-server and capiscio-core binary
-          pytest tests/unit/ -v --tb=short
+        run: pytest tests/unit/ -v --tb=short
+
+  # Verify integration tests passed for this commit
+  verify-integration:
+    name: Verify Integration Tests
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.skip_integration != 'true' }}
+    steps:
+      - name: Verify CI passed for this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+            const { data: checkRuns } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              check_name: 'SDK Server Contract Tests',
+            });
+            const passed = checkRuns.check_runs.some(
+              run => run.conclusion === 'success'
+            );
+            if (!passed) {
+              core.setFailed(
+                `Integration tests have not passed for commit ${sha}. ` +
+                `Run the integration-tests workflow first, or use skip_integration=true for emergencies.`
+              );
+            }
+            core.info(`Integration tests passed for ${sha}`);
   
   build-and-publish:
-    needs: test  # Only publish if tests pass
+    needs: [test, verify-integration]
+    if: always() && needs.test.result == 'success' && (needs.verify-integration.result == 'success' || needs.verify-integration.result == 'skipped')
     runs-on: ubuntu-latest
     
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
     name: Verify Integration Tests
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.skip_integration != 'true' }}
+    permissions:
+      checks: read
     steps:
       - name: Verify CI passed for this commit
         uses: actions/github-script@v7
@@ -55,16 +57,19 @@ jobs:
               ref: sha,
               check_name: 'SDK Server Contract Tests',
             });
-            const passed = checkRuns.check_runs.some(
-              run => run.conclusion === 'success'
-            );
+            const latestRun = checkRuns.check_runs
+              .filter(run => run.status === 'completed' && run.completed_at)
+              .sort((a, b) => new Date(b.completed_at).getTime() - new Date(a.completed_at).getTime())
+              [0];
+            const passed = latestRun && latestRun.conclusion === 'success';
             if (!passed) {
               core.setFailed(
                 `Integration tests have not passed for commit ${sha}. ` +
                 `Run the integration-tests workflow first, or use skip_integration=true for emergencies.`
               );
+              return;
             }
-            core.info(`Integration tests passed for ${sha}`);
+            core.info(`Integration tests passed for ${sha} (latest run: ${latestRun.conclusion})`);
   
   build-and-publish:
     needs: [test, verify-integration]


### PR DESCRIPTION
## GA Remediation — SDK Publish Safety (T1)

### GA-026: Gate publish on integration tests
- Add `verify-integration` job that checks for passing integration test run on the same commit
- `build-and-publish` now requires both unit tests AND integration test verification
- Add `workflow_dispatch` with `skip_integration` emergency override
- Uses GitHub check runs API to verify SDK Server Contract Tests passed