### PR TITLE
[security] SDK hardening: distinct unverified status, payload binding

### DIFF
--- a/capiscio_sdk/validators/signature.py
+++ b/capiscio_sdk/validators/signature.py
@@ -96,7 +96,6 @@ class SignatureValidator:
         if public_key:
             try:
                 import jwt
-                import json
                 
                 # Verify signature
                 decoded = jwt.decode(
@@ -107,10 +106,7 @@ class SignatureValidator:
                 )
                 
                 # Bind: compare decoded payload against caller-supplied payload
-                # Use canonical JSON comparison to avoid ordering issues
-                caller_json = json.dumps(payload, sort_keys=True, separators=(',', ':'))
-                decoded_json = json.dumps(decoded, sort_keys=True, separators=(',', ':'))
-                if caller_json != decoded_json:
+                if decoded != payload:
                     issues.append(
                         ValidationIssue(
                             severity=ValidationSeverity.ERROR,

--- a/capiscio_sdk/validators/signature.py
+++ b/capiscio_sdk/validators/signature.py
@@ -96,17 +96,33 @@ class SignatureValidator:
         if public_key:
             try:
                 import jwt
+                import json
                 
                 # Verify signature
-                jwt.decode(
+                decoded = jwt.decode(
                     signature,
                     public_key,
                     algorithms=['RS256', 'ES256', 'PS256'],
                     options={"verify_signature": True}
                 )
                 
-                # Signature is valid
-                logger.debug("Signature verified successfully")
+                # Bind: compare decoded payload against caller-supplied payload
+                # Use canonical JSON comparison to avoid ordering issues
+                caller_json = json.dumps(payload, sort_keys=True, separators=(',', ':'))
+                decoded_json = json.dumps(decoded, sort_keys=True, separators=(',', ':'))
+                if caller_json != decoded_json:
+                    issues.append(
+                        ValidationIssue(
+                            severity=ValidationSeverity.ERROR,
+                            code="PAYLOAD_MISMATCH",
+                            message="Decoded signature payload does not match the supplied payload",
+                            path="signatures",
+                        )
+                    )
+                    score = 0
+                else:
+                    # Signature is valid and payload matches
+                    logger.debug("Signature verified successfully")
                 
             except jwt.InvalidSignatureError:
                 issues.append(
@@ -156,12 +172,12 @@ class SignatureValidator:
             issues.append(
                 ValidationIssue(
                     severity=ValidationSeverity.WARNING,
-                    code="NO_PUBLIC_KEY",
-                    message="Signature format valid but no public key provided for verification",
+                    code="UNVERIFIED_FORMAT_OK",
+                    message="Signature format valid but cryptographic verification not performed (no public key provided)",
                     path="signatures",
                 )
             )
-            score = 70  # Format is OK but not verified
+            score = 50  # Format-only: below success threshold
 
         # Ensure score doesn't go negative
         score = max(0, score)


### PR DESCRIPTION
## Security Audit Remediation — SDK Python Hardening

### Changes

| Task | Severity | Description |
|------|----------|-------------|
| SEC-SDK-002 | Medium | **Minor breaking**: When no public key is provided, `validate_signature` now returns `success=False` with code `UNVERIFIED_FORMAT_OK` (score 50) instead of `success=True` (score 70). Callers that pattern-matched on success for format-only validation should check for the `UNVERIFIED_FORMAT_OK` issue code. |
| SEC-SDK-003 | Medium | After JWS verification succeeds, the decoded payload is compared against the caller-supplied payload using canonical JSON. Mismatches return `PAYLOAD_MISMATCH` error. |

### Breaking Changes
- SEC-SDK-002: `validate_signature()` without a public key previously returned `success=True`. Now returns `success=False` with a `WARNING` issue code `UNVERIFIED_FORMAT_OK`.