### PR TITLE
fix: align __version__ and CORE_VERSION with pyproject.toml 2.6.0

### DIFF
--- a/capiscio_sdk/__init__.py
+++ b/capiscio_sdk/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> result = validate_agent_card(card_dict)  # Uses Go core
 """
 
-__version__ = "2.5.0"
+__version__ = "2.6.0"
 
 # Core exports
 from .executor import CapiscioSecurityExecutor, secure, secure_agent

--- a/capiscio_sdk/_rpc/process.py
+++ b/capiscio_sdk/_rpc/process.py
@@ -52,7 +52,7 @@ def _cleanup_stale_sockets() -> None:
         pass
 
 # Binary download configuration
-CORE_VERSION = "2.5.0"
+CORE_VERSION = "2.6.0"
 GITHUB_REPO = "capiscio/capiscio-core"
 CACHE_DIR = DEFAULT_SOCKET_DIR / "bin"
 


### PR DESCRIPTION
## Problem

`__version__` in `capiscio_sdk/__init__.py` was `2.5.0` while `pyproject.toml` already declared `2.6.0`. `CORE_VERSION` in `_rpc/process.py` also pointed to `2.5.0`, meaning the SDK would download capiscio-core 2.5.0 instead of 2.6.0.

## Fix

- `capiscio_sdk/__init__.py`: `__version__` → `2.6.0`
- `capiscio_sdk/_rpc/process.py`: `CORE_VERSION` → `2.6.0` (capiscio-core v2.6.0 release exists)

## Testing

Tests use hardcoded version strings in mocked calls — not affected by this change.