### PR TITLE
chore: bump version to 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-05-14
+
+### Changed
+- **PoP default badge mode**: `connect()` now attempts Proof-of-Possession (IAL-1) badge first, with transparent fallback to CA-issued (IAL-0) badges (#69)
+
+### Fixed
+- Pass `private_key_path` through to badge keeper RPC start call (#69)
+- Fix `__version__` in `__init__.py` (was stale at "2.6.0")
+
 ## [2.7.0] - 2026-05-13
 
 ### Added
@@ -355,4 +364,3 @@ order = create_dv_order(domain="example.com", challenge_type="http-01", jwk=jwk)
 [0.3.1]: https://github.com/capiscio/capiscio-sdk-python/releases/tag/v0.3.1
 [0.3.0]: https://github.com/capiscio/capiscio-sdk-python/releases/tag/v0.3.0
 [0.1.0]: https://github.com/capiscio/capiscio-sdk-python/releases/tag/v0.1.0
-

--- a/capiscio_sdk/__init__.py
+++ b/capiscio_sdk/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> result = validate_agent_card(card_dict)  # Uses Go core
 """
 
-__version__ = "2.6.0"
+__version__ = "2.7.1"
 
 # Core exports
 from .executor import CapiscioSecurityExecutor, secure, secure_agent
@@ -151,4 +151,3 @@ __all__ = [
     "DECISION_DENY",
     "DECISION_OBSERVE",
 ]
-

--- a/capiscio_sdk/_rpc/process.py
+++ b/capiscio_sdk/_rpc/process.py
@@ -52,7 +52,7 @@ def _cleanup_stale_sockets() -> None:
         pass
 
 # Binary download configuration
-CORE_VERSION = "2.7.0"
+CORE_VERSION = "2.7.1"
 GITHUB_REPO = "capiscio/capiscio-core"
 CACHE_DIR = DEFAULT_SOCKET_DIR / "bin"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capiscio-sdk"
-version = "2.7.0"
+version = "2.7.1"
 description = "Runtime security middleware for A2A agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Version Bump: 2.7.0 → 2.7.1

Prepares the SDK for the v2.7.1 release to PyPI.

### Changes
- `pyproject.toml`: version `2.7.0` → `2.7.1`
- `capiscio_sdk/__init__.py`: `__version__` `2.6.0` → `2.7.1` (was stale since v2.6.0 release)
- `CHANGELOG.md`: added `[2.7.1]` section documenting PoP default badge mode and private_key_path fix from PR #69

### Context
- capiscio-core v2.7.1 is already released (5 platform binaries)
- PR #69 (PoP default badge) is already merged to main
- This version bump is the last step before tagging `v2.7.1` to trigger PyPI publish
- PyCon conference demos depend on `capiscio-sdk>=2.7.0` — this release includes the PoP flow needed for the enforcement demo