### PR TITLE
fix: dev_mode SimpleGuard skips agent-card.json, add client.guard property

### DIFF
--- a/capiscio_sdk/__init__.py
+++ b/capiscio_sdk/__init__.py
@@ -14,7 +14,7 @@ Example:
     >>> result = validate_agent_card(card_dict)  # Uses Go core
 """
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 # Core exports
 from .executor import CapiscioSecurityExecutor, secure, secure_agent

--- a/capiscio_sdk/connect.py
+++ b/capiscio_sdk/connect.py
@@ -212,6 +212,17 @@ class AgentIdentity:
     _keeper: Any = field(default=None, repr=False)
     _emitter: Any = field(default=None, repr=False)
     
+    @property
+    def guard(self) -> "SimpleGuard":
+        """Access the SimpleGuard instance for signing/verifying."""
+        if self._guard is None:
+            from .simple_guard import SimpleGuard
+            self._guard = SimpleGuard(
+                agent_id=self.did or self.agent_id,
+                base_dir=str(self.keys_dir.parent),
+            )
+        return self._guard
+    
     def emit(self, event_type: str, data: Dict[str, Any]) -> bool:
         """Emit an event to the registry."""
         if not self._emitter:

--- a/capiscio_sdk/simple_guard.py
+++ b/capiscio_sdk/simple_guard.py
@@ -213,13 +213,13 @@ class SimpleGuard:
     def _resolve_project_root(self, base_dir: Optional[Union[str, Path]]) -> Path:
         """Resolve the project root directory.
         
-        When agent_id is provided explicitly, uses base_dir (or cwd) directly
-        without walking up the tree looking for agent-card.json.
+        When agent_id is provided explicitly or dev_mode is True, uses base_dir
+        (or cwd) directly without walking up the tree looking for agent-card.json.
         """
         current = Path(base_dir or os.getcwd()).resolve()
         
-        # When identity params are provided, don't walk looking for agent-card.json
-        if self._explicit_agent_id:
+        # When identity params are provided or in dev_mode, don't walk looking for agent-card.json
+        if self._explicit_agent_id or self.dev_mode:
             return current
         
         search_path = current
@@ -246,7 +246,16 @@ class SimpleGuard:
             logger.info(f"Using explicit agent_id: {self.agent_id}")
             return
         
-        # Case 3: Legacy agent-card.json (deprecated path)
+        # Case 3: Dev mode — placeholder until key generation
+        # (checked before legacy agent-card.json so dev_mode isn't
+        #  broken by an A2A agent-card.json that lacks public_keys)
+        if self.dev_mode:
+            logger.info("Dev Mode: Will generate did:key identity from keypair")
+            self.agent_id = "local-dev-agent"
+            self.signing_kid = "local-dev-key"
+            return
+        
+        # Case 4: Legacy agent-card.json (deprecated path)
         agent_card_path = self.project_root / "agent-card.json"
         if agent_card_path.exists():
             logger.warning(
@@ -268,13 +277,6 @@ class SimpleGuard:
                 raise
             except Exception as e:
                 raise ConfigurationError(f"Failed to load agent-card.json: {e}")
-            return
-            
-        # Case 4: Dev mode — placeholder until key generation
-        if self.dev_mode:
-            logger.info("Dev Mode: Will generate did:key identity from keypair")
-            self.agent_id = "local-dev-agent"
-            self.signing_kid = "local-dev-key"
             return
         
         raise ConfigurationError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "capiscio-sdk"
-version = "2.7.1"
+version = "2.7.2"
 description = "Runtime security middleware for A2A agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## DX Audit Fixes

Found during a hands-on DX walkthrough of the getting-started docs with real API calls.

### Changes

**1. dev_mode now takes priority over legacy agent-card.json (Bug #1 — Critical)**

`SimpleGuard(dev_mode=True)` crashed with `ConfigurationError: agent-card.json missing 'public_keys'` when an A2A `agent-card.json` (from `validate-a2a`) existed in the working directory. The A2A agent card format doesn't have `public_keys` — that's a CapiscIO-specific field.

Fix: Reorder `_resolve_identity()` so dev_mode (Case 3) is checked before legacy agent-card.json loading (now Case 4). Also skip directory walking in `_resolve_project_root()` when `dev_mode=True`.

**2. Add `client.guard` property on AgentIdentity (Bug #6)**

`CapiscIO.connect()` returns an `AgentIdentity` with `_guard` as a private field. Users following docs had no public way to access the guard for signing. Added a `@property guard` that lazily creates a `SimpleGuard` if needed.

### Breaking Changes

None. Both changes are additive or fix broken paths.

### Testing

- Verified `SimpleGuard(dev_mode=True)` works with agent-card.json present (was crashing)
- Verified sign/verify round-trip in dev_mode
- Verified `client.guard` returns `SimpleGuard` with correct `agent_id`
- FastAPI integration test passes